### PR TITLE
Update metadata.json to claim GNOME 46 supported.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,7 @@
   "name": "VIM Alt-Tab",
   "original-authors": ["koko@kokong.info"],
   "settings-schema": "org.gnome.shell.extensions.vim-alttab",
-  "shell-version": ["45"],
+  "shell-version": ["46"],
   "url": "https://github.com/koko-ng/vim-altTab",
   "uuid": "vim-altTab@kokong.info",
   "version": 8


### PR DESCRIPTION
With this change, this extension can work without setting `Disable version validation = True` in GNOME extensions.